### PR TITLE
Some bugfixes

### DIFF
--- a/xinput_tui
+++ b/xinput_tui
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## xinput_tui
-touchpad_id=$(xinput --list | grep "Touchpad" | xargs -n 1 | grep "id=" | sed 's/id=//g')
+touchpad_id=$(xinput --list | grep -i "Touchpad" | xargs -n 1 | grep "id=" | sed 's/id=//g')
 
 toggle_natural_scrolling()
 {

--- a/xinput_tui
+++ b/xinput_tui
@@ -53,7 +53,7 @@ current_speed=$(xinput --list-props $touchpad_id | awk '/Accel Speed \(/ {print 
 	echo "Speed is now set to $speed."
 	read -r -p "${1:-Do you wish to make this setting permanent? [Y/n]} " response
     case $response in
-        [nN][oO]) 
+        [nN] | [nN][oO]) 
             false
             ;;
         *)
@@ -63,11 +63,11 @@ current_speed=$(xinput --list-props $touchpad_id | awk '/Accel Speed \(/ {print 
 	\tMatchIsTouchpad \"on\"
 	\tOption \"AccelSpeed\" \"'$speed'\"
 EndSection" > /etc/X11/xorg.conf.d/31-pointerspeed.conf'
-            ;;
+   	 echo ""
+	 echo "created file /etc/X11/xorg.conf.d/31-pointerspeed.conf."
+         ;;
     esac
-    echo ""
-    echo "created file /etc/X11/xorg.conf.d/31-pointerspeed.conf. 
-    Press any key to continue"
+    echo "Press any key to continue"
     read -s -n1
 }
 


### PR DESCRIPTION
Hi there.

Grep should consider case insensitive `touchpad` word. For example, my device is called `SynPS/2 Synaptics TouchPad`, so grep wouldn't 'detect' the device on word `Touchpad`.

The second issue I've found was that permanent save prompt accepted only whole `no` word.