### PR TITLE
Find touchpad name

### DIFF
--- a/xinput_tui
+++ b/xinput_tui
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## xinput_tui
-touchpad_driver=$(grep DRIVER /sys/class/input/mouse0/device/device/uevent | sed 's/DRIVER=//g')
-touchpad_id=$(xinput --list | grep -iE "(Touchpad|$touchpad_driver)" | xargs -n 1 | grep "id=" | sed 's/id=//g')
+touchpad_name=$(udevadm info /sys/class/input/mouse*/device | grep -E "(NAME=|TOUCHPAD=1)" | grep -m1 -B1 TOUCHPAD | grep -oE "[a-z0-9][^\"]+")
+touchpad_id=$(xinput --list | grep -iE "(Touchpad|$touchpad_name)" | xargs -n 1 | grep "id=" | sed 's/id=//g')
 
 toggle_natural_scrolling()
 {


### PR DESCRIPTION
It's possible that the touchpad system path is set different then /sys/class/input/mouse0
Better fix for issue #4